### PR TITLE
feat: add Smithery.ai configuration middleware support

### DIFF
--- a/docs/_developers/src/index.md
+++ b/docs/_developers/src/index.md
@@ -143,6 +143,34 @@ app.use((req, _res, next) => {
 - **Fields**: HTTP method, path, client IP
 - **Purpose**: Request tracing and debugging
 
+### 4. Smithery.ai Configuration Middleware
+
+```typescript
+app.use('/mcp', (req, _res, next) => {
+    if (req.query && Object.keys(req.query).length > 0) {
+        logger.debug('Smithery configuration received', { query: req.query });
+        
+        // Parse dot-notation query params and set as env vars
+        Object.entries(req.query).forEach(([key, value]) => {
+            if (typeof value === 'string') {
+                // Convert dot notation to underscore for env vars
+                // e.g., "server.port" becomes "SERVER_PORT"
+                const envKey = key.toUpperCase().replace(/\./g, '_');
+                process.env[envKey] = value;
+                logger.debug(`Set env var ${envKey}=${value}`);
+            }
+        });
+    }
+    next();
+});
+```
+
+- **Purpose**: Parse Smithery.ai configuration from query parameters
+- **Applies to**: `/mcp` endpoints only
+- **Functionality**: Converts dot-notation query params to environment variables
+- **Example**: `?AIRS_API_KEY=xxx&LOG_LEVEL=debug` sets corresponding env vars
+- **Use Case**: Smithery.ai passes configuration as query parameters for container deployments
+
 ### Endpoints
 
 #### Health Check Endpoint

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,1 +1,65 @@
-runtime: 'typescript'
+runtime: 'container'
+build:
+  dockerfile: 'docker/Dockerfile' # Path to your Dockerfile
+  dockerBuildPath: '.' # Docker build context
+startCommand:
+  type: 'http'
+  configSchema: # JSON Schema for configuration
+    type: 'object'
+    properties:
+      AIRS_API_KEY:
+        type: 'string'
+        description: 'Prisma AIRS API key for security scanning'
+      AIRS_API_URL:
+        type: 'string'
+        description: 'Prisma AIRS API URL'
+        default: 'https://service.api.aisecurity.paloaltonetworks.com'
+      AIRS_DEFAULT_PROFILE_NAME:
+        type: 'string'
+        description: 'Default profile name for AIRS scans'
+        default: 'Prisma AIRS'
+      NODE_ENV:
+        type: 'string'
+        description: 'Node environment (development/production)'
+        default: 'production'
+      PORT:
+        type: 'string'
+        description: 'Server port'
+        default: '3000'
+      LOG_LEVEL:
+        type: 'string'
+        description: 'Logging level'
+        default: 'info'
+        enum: [ 'error', 'warn', 'info', 'debug' ]
+      CACHE_TTL_SECONDS:
+        type: 'integer'
+        description: 'Cache time-to-live in seconds'
+        default: 300
+      CACHE_MAX_SIZE:
+        type: 'integer'
+        description: 'Maximum cache size'
+        default: 1000
+      RATE_LIMIT_MAX_REQUESTS:
+        type: 'integer'
+        description: 'Maximum requests per rate limit window'
+        default: 100
+      RATE_LIMIT_WINDOW_MS:
+        type: 'integer'
+        description: 'Rate limit window in milliseconds'
+        default: 60000
+      MCP_SERVER_NAME:
+        type: 'string'
+        description: 'MCP server name'
+        default: 'prisma-airs-mcp'
+      MCP_SERVER_VERSION:
+        type: 'string'
+        description: 'MCP server version'
+        default: '1.0.4'
+    required: [ 'AIRS_API_KEY' ]
+  exampleConfig:
+    AIRS_API_KEY: 'your-prisma-airs-api-key-here'
+    AIRS_API_URL: 'https://service.api.aisecurity.paloaltonetworks.com'
+    AIRS_DEFAULT_PROFILE_NAME: 'Prisma AIRS'
+    NODE_ENV: 'production'
+    PORT: '3000'
+    LOG_LEVEL: 'info'

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,25 @@ const createServer = (): void => {
         next();
     });
 
+    // Smithery.ai configuration middleware - parse query params as env vars
+    app.use('/mcp', (req, _res, next) => {
+        if (req.query && Object.keys(req.query).length > 0) {
+            logger.debug('Smithery configuration received', { query: req.query });
+            
+            // Parse dot-notation query params and set as env vars
+            Object.entries(req.query).forEach(([key, value]) => {
+                if (typeof value === 'string') {
+                    // Convert dot notation to underscore for env vars
+                    // e.g., "server.port" becomes "SERVER_PORT"
+                    const envKey = key.toUpperCase().replace(/\./g, '_');
+                    process.env[envKey] = value;
+                    logger.debug(`Set env var ${envKey}=${value}`);
+                }
+            });
+        }
+        next();
+    });
+
     // Health check endpoint
     app.get('/health', (_req: Request, res: Response) => {
         res.json({


### PR DESCRIPTION
## Summary
- Added middleware to parse Smithery.ai configuration from query parameters
- Fixed smithery.yaml to use correct container runtime and settings
- Updated developer documentation to include the new middleware

## Changes
1. **Configuration Middleware**: Added middleware that parses query parameters sent by Smithery.ai and converts them to environment variables
   - Handles dot-notation conversion (e.g., `server.port` → `SERVER_PORT`)
   - Only applies to `/mcp` endpoints
   - Logs configuration changes for debugging

2. **smithery.yaml Fixes**: 
   - Set runtime to `'container'` (was incorrectly changed to `'typescript'`)
   - Fixed dockerfile path to `'docker/Dockerfile'`
   - Updated version to 1.0.4

3. **Documentation**: Updated the developer docs to explain the new middleware

## Test Plan
- [ ] Deploy to Smithery.ai and verify configuration is properly parsed
- [ ] Test that query parameters are converted to environment variables
- [ ] Verify existing deployments continue to work

## Context
Smithery.ai passes configuration as query parameters when deploying containers. Our server wasn't parsing these, which was causing deployment failures. This PR adds the necessary middleware to handle their configuration mechanism.

🤖 Generated with [Claude Code](https://claude.ai/code)