### PR TITLE
feat: switch to TypeScript runtime for Smithery.ai deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,11 @@
     "comment:workflow": "=== Workflow Commands ===",
     "workflow:dev": "pnpm run docker:build:dev && pnpm run docker:run:dev",
     "workflow:prod:deploy": "pnpm run local:validate && pnpm run docker:build:prod && pnpm run docker:push:prod && pnpm run k8s:deploy:latest",
-    "workflow:prod:release": "pnpm run k8s:deploy:version"
+    "workflow:prod:release": "pnpm run k8s:deploy:version",
+    "comment:standard": "=== Standard NPM Scripts for Smithery ===",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
   },
   "keywords": [
     "mcp",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,4 @@
-runtime: 'container'
-build:
-  dockerfile: 'docker/Dockerfile' # Path to your Dockerfile
-  dockerBuildPath: '.' # Docker build context
+runtime: 'typescript'
 startCommand:
   type: 'http'
   configSchema: # JSON Schema for configuration


### PR DESCRIPTION
- Change runtime from 'container' to 'typescript'
- Add standard npm scripts (build, start, dev) for Smithery compatibility
- Simplify smithery.yaml configuration

Container deployment was failing immediately without logs, trying TypeScript runtime as an alternative approach.